### PR TITLE
Fix steer right bug, add flutter tests and update control panel

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -21,5 +21,7 @@ jobs:
         run: flutter pub get
       - name: Analyzing ...
         run: flutter analyze .
+      - name: Running tests
+        run: flutter test
       - name: Building app apk
         run: flutter build apk

--- a/smart_pet_buddy/lib/controlpanel.dart
+++ b/smart_pet_buddy/lib/controlpanel.dart
@@ -96,7 +96,12 @@ class ControlpanelState extends State<Controlpanel> {
     });
 
     _steer(steerRight);
-    _throttle('$currentSpeed');
+    if (isForward) {
+      _throttle('$currentSpeed');
+    }
+    if (isReversed) {
+      _throttle('$reverseSpeed');
+    }
   }
 
   void _cancelRight() {
@@ -204,9 +209,9 @@ class ControlpanelState extends State<Controlpanel> {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      alignment: Alignment.center,
-      child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+    return Scaffold( //Container
+      //alignment: Alignment.center,
+      body: Column(mainAxisAlignment: MainAxisAlignment.center, children: [ //child
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [

--- a/smart_pet_buddy/test/controlpanel_test.dart
+++ b/smart_pet_buddy/test/controlpanel_test.dart
@@ -1,251 +1,249 @@
-//
-// import 'package:flutter/material.dart';
-// import 'package:flutter_test/flutter_test.dart';
-// import 'package:smart_pet_buddy/controlpanel.dart';
-//
-// void main() {
-//
-//   //************************** Backward button *******************************
-//   testWidgets('Pressing backward button should set the car in reverse state', (WidgetTester tester) async {
-//
-//     Widget testWidget = new MediaQuery(
-//         data: new MediaQueryData(),
-//         child: new MaterialApp(home: new Controlpanel())
-//     );
-//
-//     await tester.pumpWidget(testWidget);
-//     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-//     expect(state.isReversed, isFalse);
-//
-//     await tester.tap(find.byKey(Key('backwards')));
-//     expect(state.isReversed, isTrue);
-//     expect(state.isForward, isFalse);
-//     expect(state.isRight, isFalse);
-//     expect(state.isLeft, isFalse);
-//   });
-//
-//   testWidgets('Pressing backward button should move the car in reverse', (WidgetTester tester) async {
-//
-//     Widget testWidget = new MediaQuery(
-//         data: new MediaQueryData(),
-//         child: new MaterialApp(home: new Controlpanel())
-//     );
-//
-//     await tester.pumpWidget(testWidget);
-//     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-//     expect(state.isReversed, isFalse);
-//
-//     await tester.tap(find.byKey(Key('backwards')));
-//     expect(state.isReversed, isTrue);
-//     expect(state.isForward, isFalse);
-//     expect(state.isRight, isFalse);
-//     expect(state.isLeft, isFalse);
-//     expect (state.reverseSpeed, -30);
-//     expect (state.steerNeutral, '0');
-//
-//   });
-//
-//   testWidgets('The car should stand still when isReversed is false', (WidgetTester tester) async {
-//
-//     Widget testWidget = new MediaQuery(
-//         data: new MediaQueryData(),
-//         child: new MaterialApp(home: new Controlpanel())
-//     );
-//
-//     await tester.pumpWidget(testWidget);
-//     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-//     state.isReversed = true;
-//
-//     await tester.tap(find.byKey(Key('backwards')));
-//     expect(state.isReversed, isFalse);
-//     expect(state.isForward, isFalse);
-//     expect(state.isRight, isFalse);
-//     expect(state.isLeft, isFalse);
-//     expect(state.throttleNeutral, '0');
-//   });
-//
-//   //************************** Forward button *******************************
-//   testWidgets('Pressing forward button should set the car in a forward state', (WidgetTester tester) async {
-//
-//     Widget testWidget = new MediaQuery(
-//         data: new MediaQueryData(),
-//         child: new MaterialApp(home: new Controlpanel())
-//     );
-//
-//     await tester.pumpWidget(testWidget);
-//     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-//     expect(state.isForward, isFalse);
-//
-//     await tester.tap(find.byKey(Key('forwards')));
-//     expect(state.isReversed, isFalse);
-//     expect(state.isForward, isTrue);
-//     expect(state.isRight, isFalse);
-//     expect(state.isLeft, isFalse);
-//   });
-//
-//   testWidgets('Pressing forward button should move the car forward', (WidgetTester tester) async {
-//
-//     Widget testWidget = new MediaQuery(
-//         data: new MediaQueryData(),
-//         child: new MaterialApp(home: new Controlpanel())
-//     );
-//
-//     await tester.pumpWidget(testWidget);
-//     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-//     expect(state.isForward, isFalse);
-//
-//     await tester.tap(find.byKey(Key('forwards')));
-//     expect(state.isReversed, isFalse);
-//     expect(state.isForward, isTrue);
-//     expect(state.isRight, isFalse);
-//     expect(state.isLeft, isFalse);
-//     //expect (state.currentSpeed, 0); // needs mqtt mock
-//     expect (state.steerNeutral, '0');
-//   });
-//
-//   testWidgets('The car should stand still when isForward is false', (WidgetTester tester) async {
-//
-//     Widget testWidget = new MediaQuery(
-//         data: new MediaQueryData(),
-//         child: new MaterialApp(home: new Controlpanel())
-//     );
-//
-//     await tester.pumpWidget(testWidget);
-//     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-//     state.isForward = true;
-//     await tester.tap(find.byKey(Key('forwards')));
-//     expect(state.isReversed, isFalse);
-//     expect(state.isForward, isFalse);
-//     expect(state.isRight, isFalse);
-//     expect(state.isLeft, isFalse);
-//     expect(state.throttleNeutral, '0');
-//   });
-//
-//   //************************** Left button *******************************
-//
-//   testWidgets('Pressing left button should set the car in a left state', (WidgetTester tester) async {
-//
-//     Widget testWidget = new MediaQuery(
-//         data: new MediaQueryData(),
-//         child: new MaterialApp(home: new Controlpanel())
-//     );
-//
-//     await tester.pumpWidget(testWidget);
-//     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-//     expect(state.isLeft, isFalse);
-//     expect(state.isRight, isFalse);
-//
-//     await tester.press(find.byKey(Key('left')));
-//     expect(state.isLeft, isTrue);
-//     expect(state.isRight, isFalse);
-//
-//   });
-//
-//   testWidgets('Pressing left button should turn the car left in a forward state', (WidgetTester tester) async {
-//
-//     Widget testWidget = new MediaQuery(
-//         data: new MediaQueryData(),
-//         child: new MaterialApp(home: new Controlpanel())
-//     );
-//
-//     await tester.pumpWidget(testWidget);
-//     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-//     expect(state.isLeft, isFalse);
-//     expect(state.isRight, isFalse);
-//
-//     state.isForward = true;
-//
-//     await tester.press(find.byKey(Key('left')));
-//     expect(state.isReversed, isFalse);
-//     expect(state.isRight, isFalse);
-//     expect(state.isLeft, isTrue);
-//     // expect (state.currentSpeed, 0); // needs mqtt mock
-//   });
-//
-//   testWidgets('Pressing left button should turn the car left in a reversed state', (WidgetTester tester) async {
-//
-//     Widget testWidget = new MediaQuery(
-//         data: new MediaQueryData(),
-//         child: new MaterialApp(home: new Controlpanel())
-//     );
-//
-//     await tester.pumpWidget(testWidget);
-//     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-//     expect(state.isLeft, isFalse);
-//     expect(state.isRight, isFalse);
-//
-//     state.isReversed = true;
-//
-//     await tester.press(find.byKey(Key('left')));
-//     expect(state.isForward, isFalse);
-//     expect(state.isRight, isFalse);
-//     expect(state.isLeft, isTrue);
-//     // expect (state.currentSpeed, 0); // needs mqtt mock
-//   });
-//
-//   //************************** Right button *******************************
-//
-//   testWidgets('Pressing right button should set the car in a right state', (WidgetTester tester) async {
-//
-//     Widget testWidget = new MediaQuery(
-//         data: new MediaQueryData(),
-//         child: new MaterialApp(home: new Controlpanel())
-//     );
-//
-//     await tester.pumpWidget(testWidget);
-//     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-//     expect(state.isLeft, isFalse);
-//     expect(state.isRight, isFalse);
-//
-//     await tester.press(find.byKey(Key('right')));
-//     expect(state.isLeft, isFalse);
-//     expect(state.isRight, isTrue);
-//
-//   });
-//
-//   testWidgets('Pressing right button should turn the car right in a forward state', (WidgetTester tester) async {
-//
-//     Widget testWidget = new MediaQuery(
-//         data: new MediaQueryData(),
-//         child: new MaterialApp(home: new Controlpanel())
-//     );
-//
-//     await tester.pumpWidget(testWidget);
-//     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-//     expect(state.isLeft, isFalse);
-//     expect(state.isRight, isFalse);
-//
-//     state.isForward = true;
-//
-//     await tester.press(find.byKey(Key('right')));
-//     expect(state.isReversed, isFalse);
-//     expect(state.isRight, isTrue);
-//     expect(state.isLeft, isFalse);
-//     // expect (state.currentSpeed, 0); // needs mqtt mock
-//   });
-//
-//   testWidgets('Pressing right button should turn the car right in a reversed state', (WidgetTester tester) async {
-//
-//     Widget testWidget = new MediaQuery(
-//         data: new MediaQueryData(),
-//         child: new MaterialApp(home: new Controlpanel())
-//     );
-//
-//     await tester.pumpWidget(testWidget);
-//     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-//     expect(state.isLeft, isFalse);
-//     expect(state.isRight, isFalse);
-//
-//     state.isReversed = true;
-//
-//     await tester.press(find.byKey(Key('right')));
-//     expect(state.isForward, isFalse);
-//     expect(state.isRight, isTrue);
-//     expect(state.isLeft, isFalse);
-//     // expect (state.currentSpeed, 0); // needs mqtt mock
-//   });
-//
-//
-//
-// }
+
+ import 'package:flutter/material.dart';
+ import 'package:flutter_test/flutter_test.dart';
+ import 'package:smart_pet_buddy/controlpanel.dart';
+
+ void main() {
+
+   //************************** Backward button *******************************
+   testWidgets('Pressing backward button should set the car in reverse state', (WidgetTester tester) async {
+
+     Widget testWidget = new MediaQuery(
+         data: new MediaQueryData(),
+         child: new MaterialApp(home: new Controlpanel())
+     );
+
+     await tester.pumpWidget(testWidget);
+     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
+     expect(state.isReversed, isFalse);
+
+     await tester.tap(find.byKey(Key('backwards')));
+     expect(state.isReversed, isTrue);
+     expect(state.isForward, isFalse);
+     expect(state.isRight, isFalse);
+     expect(state.isLeft, isFalse);
+   });
+
+   testWidgets('Pressing backward button should move the car in reverse', (WidgetTester tester) async {
+
+     Widget testWidget = new MediaQuery(
+         data: new MediaQueryData(),
+         child: new MaterialApp(home: new Controlpanel())
+     );
+
+     await tester.pumpWidget(testWidget);
+     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
+     expect(state.isReversed, isFalse);
+
+     await tester.tap(find.byKey(Key('backwards')));
+     expect(state.isReversed, isTrue);
+     expect(state.isForward, isFalse);
+     expect(state.isRight, isFalse);
+     expect(state.isLeft, isFalse);
+     expect (state.reverseSpeed, -30);
+     expect (state.steerNeutral, '0');
+
+   });
+
+   testWidgets('The car should stand still when isReversed is false', (WidgetTester tester) async {
+
+     Widget testWidget = new MediaQuery(
+         data: new MediaQueryData(),
+         child: new MaterialApp(home: new Controlpanel())
+     );
+
+     await tester.pumpWidget(testWidget);
+     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
+     state.isReversed = true;
+
+     await tester.tap(find.byKey(Key('backwards')));
+     expect(state.isReversed, isFalse);
+     expect(state.isForward, isFalse);
+     expect(state.isRight, isFalse);
+     expect(state.isLeft, isFalse);
+     expect(state.throttleNeutral, '0');
+   });
+
+   //************************** Forward button *******************************
+   testWidgets('Pressing forward button should set the car in a forward state', (WidgetTester tester) async {
+
+     Widget testWidget = new MediaQuery(
+         data: new MediaQueryData(),
+         child: new MaterialApp(home: new Controlpanel())
+     );
+
+     await tester.pumpWidget(testWidget);
+     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
+     expect(state.isForward, isFalse);
+
+     await tester.tap(find.byKey(Key('forwards')));
+     expect(state.isReversed, isFalse);
+     expect(state.isForward, isTrue);
+     expect(state.isRight, isFalse);
+     expect(state.isLeft, isFalse);
+   });
+
+   testWidgets('Pressing forward button should move the car forward', (WidgetTester tester) async {
+
+     Widget testWidget = new MediaQuery(
+         data: new MediaQueryData(),
+         child: new MaterialApp(home: new Controlpanel())
+     );
+
+     await tester.pumpWidget(testWidget);
+     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
+     expect(state.isForward, isFalse);
+
+     await tester.tap(find.byKey(Key('forwards')));
+     expect(state.isReversed, isFalse);
+     expect(state.isForward, isTrue);
+     expect(state.isRight, isFalse);
+     expect(state.isLeft, isFalse);
+     //expect (state.currentSpeed, 0); // needs mqtt mock
+     expect (state.steerNeutral, '0');
+   });
+
+   testWidgets('The car should stand still when isForward is false', (WidgetTester tester) async {
+
+     Widget testWidget = new MediaQuery(
+         data: new MediaQueryData(),
+         child: new MaterialApp(home: new Controlpanel())
+     );
+
+     await tester.pumpWidget(testWidget);
+     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
+     state.isForward = true;
+     await tester.tap(find.byKey(Key('forwards')));
+     expect(state.isReversed, isFalse);
+     expect(state.isForward, isFalse);
+     expect(state.isRight, isFalse);
+     expect(state.isLeft, isFalse);
+     expect(state.throttleNeutral, '0');
+   });
+
+// ************************** Left button *******************************
+
+   testWidgets('Pressing left button should set the car in a left state', (WidgetTester tester) async {
+
+     Widget testWidget = new MediaQuery(
+         data: new MediaQueryData(),
+         child: new MaterialApp(home: new Controlpanel())
+     );
+
+     await tester.pumpWidget(testWidget);
+     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
+     expect(state.isLeft, isFalse);
+     expect(state.isRight, isFalse);
+
+     await tester.press(find.byKey(Key('left')));
+     expect(state.isLeft, isTrue);
+     expect(state.isRight, isFalse);
+
+   });
+
+   testWidgets('Pressing left button should turn the car left in a forward state', (WidgetTester tester) async {
+
+     Widget testWidget = new MediaQuery(
+         data: new MediaQueryData(),
+         child: new MaterialApp(home: new Controlpanel())
+     );
+
+     await tester.pumpWidget(testWidget);
+     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
+     expect(state.isLeft, isFalse);
+     expect(state.isRight, isFalse);
+
+     state.isForward = true;
+
+     await tester.press(find.byKey(Key('left')));
+     expect(state.isReversed, isFalse);
+     expect(state.isRight, isFalse);
+     expect(state.isLeft, isTrue);
+     // expect (state.currentSpeed, 0); // needs mqtt mock
+  });
+
+   testWidgets('Pressing left button should turn the car left in a reversed state', (WidgetTester tester) async {
+
+     Widget testWidget = new MediaQuery(
+         data: new MediaQueryData(),
+         child: new MaterialApp(home: new Controlpanel())
+     );
+
+     await tester.pumpWidget(testWidget);
+     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
+     expect(state.isLeft, isFalse);
+     expect(state.isRight, isFalse);
+
+     state.isReversed = true;
+
+     await tester.press(find.byKey(Key('left')));
+     expect(state.isForward, isFalse);
+     expect(state.isRight, isFalse);
+     expect(state.isLeft, isTrue);
+     // expect (state.currentSpeed, 0); // needs mqtt mock
+   });
+
+   //************************** Right button *******************************
+
+   testWidgets('Pressing right button should set the car in a right state', (WidgetTester tester) async {
+
+     Widget testWidget = new MediaQuery(
+         data: new MediaQueryData(),
+         child: new MaterialApp(home: new Controlpanel())
+     );
+
+     await tester.pumpWidget(testWidget);
+     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
+     expect(state.isLeft, isFalse);
+     expect(state.isRight, isFalse);
+
+     await tester.press(find.byKey(Key('right')));
+     expect(state.isLeft, isFalse);
+     expect(state.isRight, isTrue);
+
+   });
+
+   testWidgets('Pressing right button should turn the car right in a forward state', (WidgetTester tester) async {
+
+     Widget testWidget = new MediaQuery(
+         data: new MediaQueryData(),
+         child: new MaterialApp(home: new Controlpanel())
+     );
+
+     await tester.pumpWidget(testWidget);
+     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
+     expect(state.isLeft, isFalse);
+     expect(state.isRight, isFalse);
+
+    state.isForward = true;
+
+     await tester.press(find.byKey(Key('right')));
+     expect(state.isReversed, isFalse);
+     expect(state.isRight, isTrue);
+    expect(state.isLeft, isFalse);
+     // expect (state.currentSpeed, 0); // needs mqtt mock
+   });
+
+  testWidgets('Pressing right button should turn the car right in a reversed state', (WidgetTester tester) async {
+
+    Widget testWidget = new MediaQuery(
+         data: new MediaQueryData(),
+         child: new MaterialApp(home: new Controlpanel())
+     );
+
+    await tester.pumpWidget(testWidget);
+     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
+     expect(state.isLeft, isFalse);
+   expect(state.isRight, isFalse);
+
+   state.isReversed = true;
+
+     await tester.press(find.byKey(Key('right')));
+     expect(state.isForward, isFalse);
+     expect(state.isRight, isTrue);
+     expect(state.isLeft, isFalse);
+     // expect (state.currentSpeed, 0); // needs mqtt mock
+   });
+
+ }
 

--- a/smart_pet_buddy/test/controlpanel_test.dart
+++ b/smart_pet_buddy/test/controlpanel_test.dart
@@ -1,249 +1,246 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:smart_pet_buddy/controlpanel.dart';
 
- import 'package:flutter/material.dart';
- import 'package:flutter_test/flutter_test.dart';
- import 'package:smart_pet_buddy/controlpanel.dart';
+void main() {
+  //************************** Backward button *******************************
+  testWidgets('Pressing backward button should set the car in reverse state',
+      (WidgetTester tester) async {
+    Widget testWidget = new MediaQuery(
+        data: new MediaQueryData(),
+        child: new MaterialApp(home: new Controlpanel()));
 
- void main() {
+    await tester.pumpWidget(testWidget);
+    ControlpanelState state =
+        tester.state<ControlpanelState>(find.byType(Controlpanel));
+    expect(state.isReversed, isFalse);
 
-   //************************** Backward button *******************************
-   testWidgets('Pressing backward button should set the car in reverse state', (WidgetTester tester) async {
+    await tester.tap(find.byKey(Key('backwards')));
+    expect(state.isReversed, isTrue);
+    expect(state.isForward, isFalse);
+    expect(state.isRight, isFalse);
+    expect(state.isLeft, isFalse);
+  });
 
-     Widget testWidget = new MediaQuery(
-         data: new MediaQueryData(),
-         child: new MaterialApp(home: new Controlpanel())
-     );
+  testWidgets('Pressing backward button should move the car in reverse',
+      (WidgetTester tester) async {
+    Widget testWidget = new MediaQuery(
+        data: new MediaQueryData(),
+        child: new MaterialApp(home: new Controlpanel()));
 
-     await tester.pumpWidget(testWidget);
-     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-     expect(state.isReversed, isFalse);
+    await tester.pumpWidget(testWidget);
+    ControlpanelState state =
+        tester.state<ControlpanelState>(find.byType(Controlpanel));
+    expect(state.isReversed, isFalse);
 
-     await tester.tap(find.byKey(Key('backwards')));
-     expect(state.isReversed, isTrue);
-     expect(state.isForward, isFalse);
-     expect(state.isRight, isFalse);
-     expect(state.isLeft, isFalse);
-   });
+    await tester.tap(find.byKey(Key('backwards')));
+    expect(state.isReversed, isTrue);
+    expect(state.isForward, isFalse);
+    expect(state.isRight, isFalse);
+    expect(state.isLeft, isFalse);
+    expect(state.reverseSpeed, -30);
+    expect(state.steerNeutral, '0');
+  });
 
-   testWidgets('Pressing backward button should move the car in reverse', (WidgetTester tester) async {
+  testWidgets('The car should stand still when isReversed is false',
+      (WidgetTester tester) async {
+    Widget testWidget = new MediaQuery(
+        data: new MediaQueryData(),
+        child: new MaterialApp(home: new Controlpanel()));
 
-     Widget testWidget = new MediaQuery(
-         data: new MediaQueryData(),
-         child: new MaterialApp(home: new Controlpanel())
-     );
+    await tester.pumpWidget(testWidget);
+    ControlpanelState state =
+        tester.state<ControlpanelState>(find.byType(Controlpanel));
+    state.isReversed = true;
 
-     await tester.pumpWidget(testWidget);
-     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-     expect(state.isReversed, isFalse);
+    await tester.tap(find.byKey(Key('backwards')));
+    expect(state.isReversed, isFalse);
+    expect(state.isForward, isFalse);
+    expect(state.isRight, isFalse);
+    expect(state.isLeft, isFalse);
+    expect(state.throttleNeutral, '0');
+  });
 
-     await tester.tap(find.byKey(Key('backwards')));
-     expect(state.isReversed, isTrue);
-     expect(state.isForward, isFalse);
-     expect(state.isRight, isFalse);
-     expect(state.isLeft, isFalse);
-     expect (state.reverseSpeed, -30);
-     expect (state.steerNeutral, '0');
+  //************************** Forward button *******************************
+  testWidgets('Pressing forward button should set the car in a forward state',
+      (WidgetTester tester) async {
+    Widget testWidget = new MediaQuery(
+        data: new MediaQueryData(),
+        child: new MaterialApp(home: new Controlpanel()));
 
-   });
+    await tester.pumpWidget(testWidget);
+    ControlpanelState state =
+        tester.state<ControlpanelState>(find.byType(Controlpanel));
+    expect(state.isForward, isFalse);
 
-   testWidgets('The car should stand still when isReversed is false', (WidgetTester tester) async {
+    await tester.tap(find.byKey(Key('forwards')));
+    expect(state.isReversed, isFalse);
+    expect(state.isForward, isTrue);
+    expect(state.isRight, isFalse);
+    expect(state.isLeft, isFalse);
+  });
 
-     Widget testWidget = new MediaQuery(
-         data: new MediaQueryData(),
-         child: new MaterialApp(home: new Controlpanel())
-     );
+  testWidgets('Pressing forward button should move the car forward',
+      (WidgetTester tester) async {
+    Widget testWidget = new MediaQuery(
+        data: new MediaQueryData(),
+        child: new MaterialApp(home: new Controlpanel()));
 
-     await tester.pumpWidget(testWidget);
-     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-     state.isReversed = true;
+    await tester.pumpWidget(testWidget);
+    ControlpanelState state =
+        tester.state<ControlpanelState>(find.byType(Controlpanel));
+    expect(state.isForward, isFalse);
 
-     await tester.tap(find.byKey(Key('backwards')));
-     expect(state.isReversed, isFalse);
-     expect(state.isForward, isFalse);
-     expect(state.isRight, isFalse);
-     expect(state.isLeft, isFalse);
-     expect(state.throttleNeutral, '0');
-   });
+    await tester.tap(find.byKey(Key('forwards')));
+    expect(state.isReversed, isFalse);
+    expect(state.isForward, isTrue);
+    expect(state.isRight, isFalse);
+    expect(state.isLeft, isFalse);
+    //expect (state.currentSpeed, 0); // needs mqtt mock
+    expect(state.steerNeutral, '0');
+  });
 
-   //************************** Forward button *******************************
-   testWidgets('Pressing forward button should set the car in a forward state', (WidgetTester tester) async {
+  testWidgets('The car should stand still when isForward is false',
+      (WidgetTester tester) async {
+    Widget testWidget = new MediaQuery(
+        data: new MediaQueryData(),
+        child: new MaterialApp(home: new Controlpanel()));
 
-     Widget testWidget = new MediaQuery(
-         data: new MediaQueryData(),
-         child: new MaterialApp(home: new Controlpanel())
-     );
-
-     await tester.pumpWidget(testWidget);
-     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-     expect(state.isForward, isFalse);
-
-     await tester.tap(find.byKey(Key('forwards')));
-     expect(state.isReversed, isFalse);
-     expect(state.isForward, isTrue);
-     expect(state.isRight, isFalse);
-     expect(state.isLeft, isFalse);
-   });
-
-   testWidgets('Pressing forward button should move the car forward', (WidgetTester tester) async {
-
-     Widget testWidget = new MediaQuery(
-         data: new MediaQueryData(),
-         child: new MaterialApp(home: new Controlpanel())
-     );
-
-     await tester.pumpWidget(testWidget);
-     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-     expect(state.isForward, isFalse);
-
-     await tester.tap(find.byKey(Key('forwards')));
-     expect(state.isReversed, isFalse);
-     expect(state.isForward, isTrue);
-     expect(state.isRight, isFalse);
-     expect(state.isLeft, isFalse);
-     //expect (state.currentSpeed, 0); // needs mqtt mock
-     expect (state.steerNeutral, '0');
-   });
-
-   testWidgets('The car should stand still when isForward is false', (WidgetTester tester) async {
-
-     Widget testWidget = new MediaQuery(
-         data: new MediaQueryData(),
-         child: new MaterialApp(home: new Controlpanel())
-     );
-
-     await tester.pumpWidget(testWidget);
-     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-     state.isForward = true;
-     await tester.tap(find.byKey(Key('forwards')));
-     expect(state.isReversed, isFalse);
-     expect(state.isForward, isFalse);
-     expect(state.isRight, isFalse);
-     expect(state.isLeft, isFalse);
-     expect(state.throttleNeutral, '0');
-   });
+    await tester.pumpWidget(testWidget);
+    ControlpanelState state =
+        tester.state<ControlpanelState>(find.byType(Controlpanel));
+    state.isForward = true;
+    await tester.tap(find.byKey(Key('forwards')));
+    expect(state.isReversed, isFalse);
+    expect(state.isForward, isFalse);
+    expect(state.isRight, isFalse);
+    expect(state.isLeft, isFalse);
+    expect(state.throttleNeutral, '0');
+  });
 
 // ************************** Left button *******************************
 
-   testWidgets('Pressing left button should set the car in a left state', (WidgetTester tester) async {
+  testWidgets('Pressing left button should set the car in a left state',
+      (WidgetTester tester) async {
+    Widget testWidget = new MediaQuery(
+        data: new MediaQueryData(),
+        child: new MaterialApp(home: new Controlpanel()));
 
-     Widget testWidget = new MediaQuery(
-         data: new MediaQueryData(),
-         child: new MaterialApp(home: new Controlpanel())
-     );
+    await tester.pumpWidget(testWidget);
+    ControlpanelState state =
+        tester.state<ControlpanelState>(find.byType(Controlpanel));
+    expect(state.isLeft, isFalse);
+    expect(state.isRight, isFalse);
 
-     await tester.pumpWidget(testWidget);
-     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-     expect(state.isLeft, isFalse);
-     expect(state.isRight, isFalse);
-
-     await tester.press(find.byKey(Key('left')));
-     expect(state.isLeft, isTrue);
-     expect(state.isRight, isFalse);
-
-   });
-
-   testWidgets('Pressing left button should turn the car left in a forward state', (WidgetTester tester) async {
-
-     Widget testWidget = new MediaQuery(
-         data: new MediaQueryData(),
-         child: new MaterialApp(home: new Controlpanel())
-     );
-
-     await tester.pumpWidget(testWidget);
-     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-     expect(state.isLeft, isFalse);
-     expect(state.isRight, isFalse);
-
-     state.isForward = true;
-
-     await tester.press(find.byKey(Key('left')));
-     expect(state.isReversed, isFalse);
-     expect(state.isRight, isFalse);
-     expect(state.isLeft, isTrue);
-     // expect (state.currentSpeed, 0); // needs mqtt mock
+    await tester.press(find.byKey(Key('left')));
+    expect(state.isLeft, isTrue);
+    expect(state.isRight, isFalse);
   });
 
-   testWidgets('Pressing left button should turn the car left in a reversed state', (WidgetTester tester) async {
+  testWidgets(
+      'Pressing left button should turn the car left in a forward state',
+      (WidgetTester tester) async {
+    Widget testWidget = new MediaQuery(
+        data: new MediaQueryData(),
+        child: new MaterialApp(home: new Controlpanel()));
 
-     Widget testWidget = new MediaQuery(
-         data: new MediaQueryData(),
-         child: new MaterialApp(home: new Controlpanel())
-     );
-
-     await tester.pumpWidget(testWidget);
-     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-     expect(state.isLeft, isFalse);
-     expect(state.isRight, isFalse);
-
-     state.isReversed = true;
-
-     await tester.press(find.byKey(Key('left')));
-     expect(state.isForward, isFalse);
-     expect(state.isRight, isFalse);
-     expect(state.isLeft, isTrue);
-     // expect (state.currentSpeed, 0); // needs mqtt mock
-   });
-
-   //************************** Right button *******************************
-
-   testWidgets('Pressing right button should set the car in a right state', (WidgetTester tester) async {
-
-     Widget testWidget = new MediaQuery(
-         data: new MediaQueryData(),
-         child: new MaterialApp(home: new Controlpanel())
-     );
-
-     await tester.pumpWidget(testWidget);
-     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-     expect(state.isLeft, isFalse);
-     expect(state.isRight, isFalse);
-
-     await tester.press(find.byKey(Key('right')));
-     expect(state.isLeft, isFalse);
-     expect(state.isRight, isTrue);
-
-   });
-
-   testWidgets('Pressing right button should turn the car right in a forward state', (WidgetTester tester) async {
-
-     Widget testWidget = new MediaQuery(
-         data: new MediaQueryData(),
-         child: new MaterialApp(home: new Controlpanel())
-     );
-
-     await tester.pumpWidget(testWidget);
-     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-     expect(state.isLeft, isFalse);
-     expect(state.isRight, isFalse);
+    await tester.pumpWidget(testWidget);
+    ControlpanelState state =
+        tester.state<ControlpanelState>(find.byType(Controlpanel));
+    expect(state.isLeft, isFalse);
+    expect(state.isRight, isFalse);
 
     state.isForward = true;
 
-     await tester.press(find.byKey(Key('right')));
-     expect(state.isReversed, isFalse);
-     expect(state.isRight, isTrue);
-    expect(state.isLeft, isFalse);
-     // expect (state.currentSpeed, 0); // needs mqtt mock
-   });
+    await tester.press(find.byKey(Key('left')));
+    expect(state.isReversed, isFalse);
+    expect(state.isRight, isFalse);
+    expect(state.isLeft, isTrue);
+    // expect (state.currentSpeed, 0); // needs mqtt mock
+  });
 
-  testWidgets('Pressing right button should turn the car right in a reversed state', (WidgetTester tester) async {
-
+  testWidgets(
+      'Pressing left button should turn the car left in a reversed state',
+      (WidgetTester tester) async {
     Widget testWidget = new MediaQuery(
-         data: new MediaQueryData(),
-         child: new MaterialApp(home: new Controlpanel())
-     );
+        data: new MediaQueryData(),
+        child: new MaterialApp(home: new Controlpanel()));
 
     await tester.pumpWidget(testWidget);
-     ControlpanelState state = tester.state<ControlpanelState>(find.byType(Controlpanel));
-     expect(state.isLeft, isFalse);
-   expect(state.isRight, isFalse);
+    ControlpanelState state =
+        tester.state<ControlpanelState>(find.byType(Controlpanel));
+    expect(state.isLeft, isFalse);
+    expect(state.isRight, isFalse);
 
-   state.isReversed = true;
+    state.isReversed = true;
 
-     await tester.press(find.byKey(Key('right')));
-     expect(state.isForward, isFalse);
-     expect(state.isRight, isTrue);
-     expect(state.isLeft, isFalse);
-     // expect (state.currentSpeed, 0); // needs mqtt mock
-   });
+    await tester.press(find.byKey(Key('left')));
+    expect(state.isForward, isFalse);
+    expect(state.isRight, isFalse);
+    expect(state.isLeft, isTrue);
+    // expect (state.currentSpeed, 0); // needs mqtt mock
+  });
 
- }
+  //************************** Right button *******************************
 
+  testWidgets('Pressing right button should set the car in a right state',
+      (WidgetTester tester) async {
+    Widget testWidget = new MediaQuery(
+        data: new MediaQueryData(),
+        child: new MaterialApp(home: new Controlpanel()));
+
+    await tester.pumpWidget(testWidget);
+    ControlpanelState state =
+        tester.state<ControlpanelState>(find.byType(Controlpanel));
+    expect(state.isLeft, isFalse);
+    expect(state.isRight, isFalse);
+
+    await tester.press(find.byKey(Key('right')));
+    expect(state.isLeft, isFalse);
+    expect(state.isRight, isTrue);
+  });
+
+  testWidgets(
+      'Pressing right button should turn the car right in a forward state',
+      (WidgetTester tester) async {
+    Widget testWidget = new MediaQuery(
+        data: new MediaQueryData(),
+        child: new MaterialApp(home: new Controlpanel()));
+
+    await tester.pumpWidget(testWidget);
+    ControlpanelState state =
+        tester.state<ControlpanelState>(find.byType(Controlpanel));
+    expect(state.isLeft, isFalse);
+    expect(state.isRight, isFalse);
+
+    state.isForward = true;
+
+    await tester.press(find.byKey(Key('right')));
+    expect(state.isReversed, isFalse);
+    expect(state.isRight, isTrue);
+    expect(state.isLeft, isFalse);
+    // expect (state.currentSpeed, 0); // needs mqtt mock
+  });
+
+  testWidgets(
+      'Pressing right button should turn the car right in a reversed state',
+      (WidgetTester tester) async {
+    Widget testWidget = new MediaQuery(
+        data: new MediaQueryData(),
+        child: new MaterialApp(home: new Controlpanel()));
+
+    await tester.pumpWidget(testWidget);
+    ControlpanelState state =
+        tester.state<ControlpanelState>(find.byType(Controlpanel));
+    expect(state.isLeft, isFalse);
+    expect(state.isRight, isFalse);
+
+    state.isReversed = true;
+
+    await tester.press(find.byKey(Key('right')));
+    expect(state.isForward, isFalse);
+    expect(state.isRight, isTrue);
+    expect(state.isLeft, isFalse);
+    // expect (state.currentSpeed, 0); // needs mqtt mock
+  });
+}


### PR DESCRIPTION
Fixes #39.

- Did a minor fix in the control panel. No Material widget found for the icon buttons caused problems with testing. 
- Fixed steer right bug when the car is in reverse.
- Added tests and automated running them in flutter CI.