### PR TITLE
Remove go back arrow from appbar when logged in

### DIFF
--- a/smart_pet_buddy/lib/signin_page.dart
+++ b/smart_pet_buddy/lib/signin_page.dart
@@ -143,8 +143,11 @@ class _EmailPasswordFormState extends State<_EmailPasswordForm> {
         ),
       );
       //added this to navigate to controlpanel when signed in
-      Navigator.of(context).push(
-          MaterialPageRoute(builder: (BuildContext context) => BottomBar(widget.app)));
+
+      Navigator.of(context).popUntil((route) => route.isFirst);
+      Navigator.of(context).pushReplacement(
+          MaterialPageRoute(builder: (BuildContext context) => new BottomBar(widget.app)));
+
     } catch (e) {
       Scaffold.of(context).showSnackBar(
         const SnackBar(

--- a/smart_pet_buddy/pubspec.lock
+++ b/smart_pet_buddy/pubspec.lock
@@ -406,27 +406,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
-  video_player:
-    dependency: "direct main"
-    description:
-      name: video_player
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.1"
-  video_player_platform_interface:
-    dependency: transitive
-    description:
-      name: video_player_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.1.0"
-  video_player_web:
-    dependency: transitive
-    description:
-      name: video_player_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
 sdks:
   dart: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.0"


### PR DESCRIPTION
Fix navigation so that user cannot bo back when logged in. They now have to sign out instead 

#### Before
![NavigationBefore](https://user-images.githubusercontent.com/63287104/117956288-32a28c80-b319-11eb-95e2-bcd84f8ab5eb.png)

#### After
![NavigationAfter](https://user-images.githubusercontent.com/63287104/117956307-37674080-b319-11eb-8ec8-6a9b898b0fbe.png)
